### PR TITLE
Using DataProvider to split test cases from method

### DIFF
--- a/tests/KeywordExtractor/Modifiers/Filters/BlacklistFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/BlacklistFilterTest.php
@@ -6,31 +6,35 @@ use PHPUnit\Framework\TestCase;
 
 class BlacklistFilterTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
+    {
+        return [
+            [
+                'leading',
+                'leading',
+            ],
+            [
+                'team',
+                '',
+            ],
+            [
+                'leading team',
+                '',
+            ],
+            [
+                'a leading team',
+                'a leading team',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($inputText, $expected)
     {
         $filter = new BlacklistFilter(['team', 'lead', 'net', 'leading team']);
 
-        $inputsOutputs = [
-            [
-                'i' => 'leading',
-                'o' => 'leading',
-            ],
-            [
-                'i' => 'team',
-                'o' => '',
-            ],
-            [
-                'i' => 'leading team',
-                'o' => '',
-            ],
-            [
-                'i' => 'a leading team',
-                'o' => 'a leading team',
-            ],
-        ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyToken($inputOutput['i']));
-        }
+        $this->assertEquals($expected, $filter->modifyToken($inputText));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Filters/EmailFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/EmailFilterTest.php
@@ -6,31 +6,35 @@ use PHPUnit\Framework\TestCase;
 
 class EmailFilterTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
+    {
+        return [
+            [
+                'test@example.com.',
+                '.',
+            ],
+            [
+                'this contains an email e.g. test@example.com.',
+                'this contains an email e.g. .',
+            ],
+            [
+                'this contains an email e.g. invalid@email.',
+                'this contains an email e.g. invalid@email.',
+            ],
+            [
+                'this contains two emails valid@gmail.com and valid2@gmail.com',
+                'this contains two emails  and ',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($inputText, $expected)
     {
         $filter = new EmailFilter();
 
-        $inputsOutputs = [
-            [
-                'i' => 'test@example.com.',
-                'o' => '.',
-            ],
-            [
-                'i' => 'this contains an email e.g. test@example.com.',
-                'o' => 'this contains an email e.g. .',
-            ],
-            [
-                'i' => 'this contains an email e.g. invalid@email.',
-                'o' => 'this contains an email e.g. invalid@email.',
-            ],
-            [
-                'i' => 'this contains two emails valid@gmail.com and valid2@gmail.com',
-                'o' => 'this contains two emails  and ',
-            ],
-        ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyToken($inputOutput['i']));
-        }
+        $this->assertEquals($expected, $filter->modifyToken($inputText));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Filters/EmptyFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/EmptyFilterTest.php
@@ -6,63 +6,71 @@ use PHPUnit\Framework\TestCase;
 
 class EmptyFilterTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
     {
-        $filter = new EmptyFilter();
-
-        $inputsOutputs = [
+        return [
             [
-                'i' => '',
-                'o' => '',
+                '',
+                '',
             ],
             [
-                'i' => 0,
-                'o' => 0,
+                0,
+                0,
             ],
             [
-                'i' => '0',
-                'o' => '0',
+                '0',
+                '0',
             ],
             [
-                'i' => '0 ',
-                'o' => '0 ',
+                '0 ',
+                '0 ',
             ],
             [
-                'i' => 'test 0',
-                'o' => 'test 0',
+                'test 0',
+                'test 0',
             ],
             [
-                'i' => '   ',
-                'o' => '',
+                '   ',
+                '',
             ],
         ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyToken($inputOutput['i']));
-        }
     }
 
-    public function testModifyArray()
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($inputText, $expected)
     {
         $filter = new EmptyFilter();
 
-        $inputsOutputs = [
+        $this->assertEquals($expected, $filter->modifyToken($inputText));
+    }
+
+    public function modifyArrayProvider()
+    {
+        return [
             [
-                'i' => [],
-                'o' => [],
+                [],
+                [],
             ],
             [
-                'i' => ['test', 1, 0, '', '0', 'c#'],
-                'o' => [0 => 'test', 1 => 1, 2 => 0, 4 => '0', 5 => 'c#'],
+                ['test', 1, 0, '', '0', 'c#'],
+                [0 => 'test', 1 => 1, 2 => 0, 4 => '0', 5 => 'c#'],
             ],
             [
-                'i' => ['test 0', 1, 0, ' test', '0', ' '],
-                'o' => ['test 0', 1, 0, ' test', '0'],
+                ['test 0', 1, 0, ' test', '0', ' '],
+                ['test 0', 1, 0, ' test', '0'],
             ],
         ];
+    }
 
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyTokens($inputOutput['i']));
-        }
+    /**
+     * @dataProvider modifyArrayProvider
+     */
+    public function testModifyArray($inputText, $expected)
+    {
+        $filter = new EmptyFilter();
+
+        $this->assertEquals($expected, $filter->modifyTokens($inputText));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Filters/IndexBlacklistFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/IndexBlacklistFilterTest.php
@@ -6,52 +6,57 @@ use PHPUnit\Framework\TestCase;
 
 class IndexBlacklistFilterTest extends TestCase
 {
-    public function testModifyTokens()
+    public function modifyTokensProvider()
     {
-        $inputsOutputs = [
+        return [
             [
-                'i' => [
+                [
                     'words'   => [1, 2, 'test', '1test', ''],
                     'indexes' => [1, 3],
                 ],
-                'o' => [0 => 1, 2 => 'test', 4 => ''],
+                [0 => 1, 2 => 'test', 4 => ''],
             ],
             [
-                'i' => [
+                [
                     'words'   => [1, 2, 'test', '1test', ''],
                     'indexes' => [0, 1, 2, 3, 4, 5, 6],
                 ],
-                'o' => [],
+                [],
             ],
             [
-                'i' => [
+                [
                     'words'   => [],
                     'indexes' => [0, 1, 2, 3, 4, 5, 6],
                 ],
-                'o' => [],
+                [],
             ],
             [
-                'i' => [
+                [
                     'words'   => [1, 2, 'test', '1test', ''],
                     'indexes' => [],
                 ],
-                'o' => [1, 2, 'test', '1test', ''],
+                [1, 2, 'test', '1test', ''],
             ],
         ];
+    }
 
-        foreach ($inputsOutputs as $inputOutput) {
-            $filter = new IndexBlacklistFilter($inputOutput['i']['indexes']);
+    /**
+     * @dataProvider modifyTokensProvider
+     */
+    public function testModifyTokens($inputTexts, $expected)
+    {
+        $filter = new IndexBlacklistFilter($inputTexts['indexes']);
 
-            $this->assertEquals(
-                $inputOutput['o'],
-                $filter->modifyTokens($inputOutput['i']['words'])
-            );
-        }
+        $this->assertEquals(
+            $expected,
+            $filter->modifyTokens($inputTexts['words'])
+        );
     }
 
     public function testModifyToken()
     {
         $filter = new IndexBlacklistFilter([1, 2, 3]);
+
         $this->assertEquals('dummy', $filter->modifyToken('dummy'));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Filters/NumberFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/NumberFilterTest.php
@@ -6,39 +6,43 @@ use PHPUnit\Framework\TestCase;
 
 class NumberFilterTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
+    {
+        return [
+            [
+                '1',
+                '',
+            ],
+            [
+                '123',
+                '',
+            ],
+            [
+                1,
+                '',
+            ],
+            [
+                123,
+                '',
+            ],
+            [
+                'test1',
+                'test1',
+            ],
+            [
+                'test 1',
+                'test 1',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($inputText, $expected)
     {
         $filter = new NumberFilter();
 
-        $inputsOutputs = [
-            [
-                'i' => '1',
-                'o' => '',
-            ],
-            [
-                'i' => '123',
-                'o' => '',
-            ],
-            [
-                'i' => 1,
-                'o' => '',
-            ],
-            [
-                'i' => 123,
-                'o' => '',
-            ],
-            [
-                'i' => 'test1',
-                'o' => 'test1',
-            ],
-            [
-                'i' => 'test 1',
-                'o' => 'test 1',
-            ],
-        ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyToken($inputOutput['i']));
-        }
+        $this->assertEquals($expected, $filter->modifyToken($inputText));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Filters/PunctuationFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/PunctuationFilterTest.php
@@ -6,36 +6,40 @@ use PHPUnit\Framework\TestCase;
 
 class PunctuationFilterTest extends TestCase
 {
-    public function testModifyArray()
+    public function modifyArrayProvider()
+    {
+        return [
+            [
+                ['test.', '.test', '.', '.test.', '', 'node.js?', 'node.js???', 'c#'],
+                ['test', '.test', '', '.test', '', 'node.js', 'node.js', 'c#'],
+            ],
+            [
+                [],
+                [],
+            ],
+            [
+                ['0', 0, '', 1],
+                ['0', 0, '', 1],
+            ],
+            [
+                ['visual studio 2018', 'knockout.js', '- knockout...js?'],
+                ['visual studio 2018', 'knockout.js', '- knockout...js'],
+            ],
+            [
+                ['(visual studio 2018', '(c#', '"c'],
+                ['visual studio 2018', 'c#', 'c'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyArrayProvider
+     */
+    public function testModifyArray($inputText, $expected)
     {
         $filter = new PunctuationFilter();
 
-        $inputsOutputs = [
-            [
-                'i' => ['test.', '.test', '.', '.test.', '', 'node.js?', 'node.js???', 'c#'],
-                'o' => ['test', '.test', '', '.test', '', 'node.js', 'node.js', 'c#'],
-            ],
-            [
-                'i' => [],
-                'o' => [],
-            ],
-            [
-                'i' => ['0', 0, '', 1],
-                'o' => ['0', 0, '', 1],
-            ],
-            [
-                'i' => ['visual studio 2018', 'knockout.js', '- knockout...js?'],
-                'o' => ['visual studio 2018', 'knockout.js', '- knockout...js'],
-            ],
-            [
-                'i' => ['(visual studio 2018', '(c#', '"c'],
-                'o' => ['visual studio 2018', 'c#', 'c'],
-            ],
-        ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyTokens($inputOutput['i']));
-        }
+        $this->assertEquals($expected, $filter->modifyTokens($inputText));
     }
 
     public function testGetRightPunctuations()

--- a/tests/KeywordExtractor/Modifiers/Filters/SalaryFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/SalaryFilterTest.php
@@ -6,119 +6,123 @@ use PHPUnit\Framework\TestCase;
 
 class SalaryFilterTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
+    {
+        return [
+            [
+                'test123',
+                'test123',
+            ],
+            [
+                '123test',
+                '123test',
+            ],
+            [
+                'test123test',
+                'test123test',
+            ],
+            [
+                '12345',
+                '',
+            ],
+            [
+                '12.34',
+                '',
+            ],
+            [
+                '12.3456',
+                '',
+            ],
+            [
+                '$40',
+                '',
+            ],
+            [
+                '$119,921.00',
+                '',
+            ],
+            [
+                '$27.50',
+                '',
+            ],
+            [
+                '$490.5',
+                '',
+            ],
+            [
+                '$5',
+                '',
+            ],
+            [
+                '$65,100',
+                '',
+            ],
+            [
+                '$76,611',
+                '',
+            ],
+            [
+                '$70k',
+                '',
+            ],
+            [
+                '$150k',
+                '',
+            ],
+            [
+                '$27ph',
+                '',
+            ],
+            [
+                '$3b',
+                '',
+            ],
+            [
+                '$5m',
+                '',
+            ],
+            [
+                '$850/day',
+                '',
+            ],
+            [
+                '$150hr',
+                '',
+            ],
+            [
+                '$150hour',
+                '',
+            ],
+            [
+                '$150/hr',
+                '',
+            ],
+            [
+                '$150/hour',
+                '',
+            ],
+            [
+                '150/hour',
+                '',
+            ],
+            [
+                'example/hour',
+                'example/hour',
+            ],
+            [
+                'c#',
+                'c#',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($inputText, $expected)
     {
         $filter = new SalaryFilter();
 
-        $inputsOutputs = [
-            [
-                'i' => 'test123',
-                'o' => 'test123',
-            ],
-            [
-                'i' => '123test',
-                'o' => '123test',
-            ],
-            [
-                'i' => 'test123test',
-                'o' => 'test123test',
-            ],
-            [
-                'i' => '12345',
-                'o' => '',
-            ],
-            [
-                'i' => '12.34',
-                'o' => '',
-            ],
-            [
-                'i' => '12.3456',
-                'o' => '',
-            ],
-            [
-                'i' => '$40',
-                'o' => '',
-            ],
-            [
-                'i' => '$119,921.00',
-                'o' => '',
-            ],
-            [
-                'i' => '$27.50',
-                'o' => '',
-            ],
-            [
-                'i' => '$490.5',
-                'o' => '',
-            ],
-            [
-                'i' => '$5',
-                'o' => '',
-            ],
-            [
-                'i' => '$65,100',
-                'o' => '',
-            ],
-            [
-                'i' => '$76,611',
-                'o' => '',
-            ],
-            [
-                'i' => '$70k',
-                'o' => '',
-            ],
-            [
-                'i' => '$150k',
-                'o' => '',
-            ],
-            [
-                'i' => '$27ph',
-                'o' => '',
-            ],
-            [
-                'i' => '$3b',
-                'o' => '',
-            ],
-            [
-                'i' => '$5m',
-                'o' => '',
-            ],
-            [
-                'i' => '$850/day',
-                'o' => '',
-            ],
-            [
-                'i' => '$150hr',
-                'o' => '',
-            ],
-            [
-                'i' => '$150hour',
-                'o' => '',
-            ],
-            [
-                'i' => '$150/hr',
-                'o' => '',
-            ],
-            [
-                'i' => '$150/hour',
-                'o' => '',
-            ],
-            [
-                'i' => '150/hour',
-                'o' => '',
-            ],
-            [
-                'i' => 'example/hour',
-                'o' => 'example/hour',
-            ],
-            [
-                'i' => 'c#',
-                'o' => 'c#',
-            ],
-        ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyToken($inputOutput['i']));
-        }
+        $this->assertEquals($expected, $filter->modifyToken($inputText));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Filters/UrlFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/UrlFilterTest.php
@@ -6,51 +6,55 @@ use PHPUnit\Framework\TestCase;
 
 class UrlFilterTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
+    {
+        return [
+            [
+                'http://www.example.com.au/example',
+                '',
+            ],
+            [
+                'https://www.example.com',
+                '',
+            ],
+            [
+                'www.example.com/example',
+                'www.example.com/example',
+            ],
+            [
+                'example.com',
+                'example.com',
+            ],
+            [
+                'www.facebook.com/example',
+                'www.facebook.com/example',
+            ],
+            [
+                'www.example.com',
+                'www.example.com',
+            ],
+            [
+                'example/example/example',
+                'example/example/example',
+            ],
+            [
+                'www.twitter.com/example',
+                'www.twitter.com/example',
+            ],
+            [
+                'example.example',
+                'example.example',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($inputText, $expected)
     {
         $filter = new UrlFilter();
 
-        $inputsOutputs = [
-            [
-                'i' => 'http://www.example.com.au/example',
-                'o' => '',
-            ],
-            [
-                'i' => 'https://www.example.com',
-                'o' => '',
-            ],
-            [
-                'i' => 'www.example.com/example',
-                'o' => 'www.example.com/example',
-            ],
-            [
-                'i' => 'example.com',
-                'o' => 'example.com',
-            ],
-            [
-                'i' => 'www.facebook.com/example',
-                'o' => 'www.facebook.com/example',
-            ],
-            [
-                'i' => 'www.example.com',
-                'o' => 'www.example.com',
-            ],
-            [
-                'i' => 'example/example/example',
-                'o' => 'example/example/example',
-            ],
-            [
-                'i' => 'www.twitter.com/example',
-                'o' => 'www.twitter.com/example',
-            ],
-            [
-                'i' => 'example.example',
-                'o' => 'example.example',
-            ],
-        ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyToken($inputOutput['i']));
-        }
+        $this->assertEquals($expected, $filter->modifyToken($inputText));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Filters/WhitelistFilterTest.php
+++ b/tests/KeywordExtractor/Modifiers/Filters/WhitelistFilterTest.php
@@ -6,43 +6,47 @@ use PHPUnit\Framework\TestCase;
 
 class WhitelistFilterTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
+    {
+        return [
+            [
+                'leading',
+                '',
+            ],
+            [
+                'team',
+                '',
+            ],
+            [
+                'leading team',
+                '',
+            ],
+            [
+                'c# dev',
+                '',
+            ],
+            [
+                'c#',
+                'c#',
+            ],
+            [
+                'php',
+                'php',
+            ],
+            [
+                'a leading team',
+                '',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($inputText, $expected)
     {
         $filter = new WhitelistFilter(['php', 'c#', '.net']);
 
-        $inputsOutputs = [
-            [
-                'i' => 'leading',
-                'o' => '',
-            ],
-            [
-                'i' => 'team',
-                'o' => '',
-            ],
-            [
-                'i' => 'leading team',
-                'o' => '',
-            ],
-            [
-                'i' => 'c# dev',
-                'o' => '',
-            ],
-            [
-                'i' => 'c#',
-                'o' => 'c#',
-            ],
-            [
-                'i' => 'php',
-                'o' => 'php',
-            ],
-            [
-                'i' => 'a leading team',
-                'o' => '',
-            ],
-        ];
-
-        foreach ($inputsOutputs as $inputOutput) {
-            $this->assertEquals($inputOutput['o'], $filter->modifyToken($inputOutput['i']));
-        }
+        $this->assertEquals($expected, $filter->modifyToken($inputText));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Transformers/LowerCaseTransformerTest.php
+++ b/tests/KeywordExtractor/Modifiers/Transformers/LowerCaseTransformerTest.php
@@ -9,6 +9,7 @@ class LowerCaseTransformerTest extends TestCase
     public function testModifyText()
     {
         $transformer = new LowerCaseTransformer();
+
         $this->assertEquals('this is a test', $transformer->modifyToken('This is A TEST'));
     }
 }

--- a/tests/KeywordExtractor/Modifiers/Transformers/TokenTransformerTest.php
+++ b/tests/KeywordExtractor/Modifiers/Transformers/TokenTransformerTest.php
@@ -6,10 +6,27 @@ use PHPUnit\Framework\TestCase;
 
 class TokenTransformerTest extends TestCase
 {
-    public function testModifyText()
+    public function modifyTextProvider()
+    {
+        return [
+            [
+                ['This', 'is', 'A', 'TEST'],
+                'This is A TEST',
+            ],
+            [
+                ['This', 'is', 'A', 'TEST.'],
+                'This is A TEST.',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider modifyTextProvider
+     */
+    public function testModifyText($expected, $inputText)
     {
         $transformer = new TokenTransformer();
-        $this->assertEquals(['This', 'is', 'A', 'TEST'], $transformer->modifyToken('This is A TEST'));
-        $this->assertEquals(['This', 'is', 'A', 'TEST.'], $transformer->modifyToken('This is A TEST.'));
+
+        $this->assertEquals($expected, $transformer->modifyToken($inputText));
     }
 }


### PR DESCRIPTION
# Changed log
- Using `DataProvider` to split test cases from test methods with assertions.