### PR TITLE
Break the compatibility and rename the run method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,20 @@ You can install the package via composer:
 composer require keyword-extractor/keyword-extractor
 ```
 
-- Extract the keywords:
+
+## Usage
+
+The `KeywordExtractor` provides the following public methods:
+- [extract](#usage-of-extract)($text, $sortBy, $sortDir)               # provide extracted keywords with additional information
+- [extractKeywordsOnly](#usage-of-extractkeywordsonly)($text, $sortBy, $sortDir)   # provide extracted keywords only
+
+### Usage of extract()
+
+Extracting keywords:
 ```
 $keywordExtractor = new KeywordExtractor();
 $text = 'This is a simple sentence.';
-$result = $keywordExtractor->run($text);
+$result = $keywordExtractor->extract($text);
 ```
 
 The result with the default modifiers and no sorting values will be:
@@ -48,13 +57,9 @@ Array
                                 (
                                     [0] => 3
                                 )
-
                         )
-
                 )
-
         )
-
     [sentenc] => Array
         (
             [frequency] => 1
@@ -67,13 +72,9 @@ Array
                                 (
                                     [0] => 4
                                 )
-
                         )
-
                 )
-
         )
-
 )
 ```
 
@@ -121,9 +122,7 @@ Array
                                 (
                                     [0] => 3
                                 )
-
                         )
-
                     [1] => Array
                         (
                             [ngram] => simple
@@ -131,13 +130,9 @@ Array
                                 (
                                     [0] => 6
                                 )
-
                         )
-
                 )
-
         )
-
     [sentenc] => Array
         (
             [frequency] => 2
@@ -150,9 +145,7 @@ Array
                                 (
                                     [0] => 4
                                 )
-
                         )
-
                     [1] => Array
                         (
                             [ngram] => sentence.
@@ -160,13 +153,9 @@ Array
                                 (
                                     [0] => 7
                                 )
-
                         )
-
                 )
-
         )
-
 )
 ```
 
@@ -194,13 +183,9 @@ Array
                                 (
                                     [0] => 4
                                 )
-
                         )
-
                 )
-
         )
-
 )
 ```
 
@@ -228,9 +213,7 @@ Array
                                 (
                                     [0] => 0
                                 )
-
                         )
-
                     [1] => Array
                         (
                             [ngram] => sentence
@@ -238,15 +221,30 @@ Array
                                 (
                                     [0] => 2
                                 )
-
                         )
-
                 )
-
             [minOccurrencesDistance] => 1
         )
-
 )
+```
+
+### Usage of extractKeywordsOnly()
+
+Extracting keywords only:
+```
+$keywordExtractor = new KeywordExtractor();
+$text = 'This is a simple sentence.';
+$result = $keywordExtractor->extractKeywordsOnly($text);
+```
+
+The result will be:
+```php
+array(2) {
+  [0]=>
+  string(6) "simple"
+  [1]=>
+  string(8) "sentence"
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ composer require keyword-extractor/keyword-extractor
 ## Usage
 
 The `KeywordExtractor` provides the following public methods:
-- extract($text, $sortBy, $sortDir) - provides keywords with additional information ([usage](#usage-of-extract))
-- extractKeywordsOnly($text, $sortBy, $sortDir) - provides keywords only ([usage](#usage-of-extractkeywordsonly))
+- **extract($text, $sortBy, $sortDir)** - provides keywords with additional information ([usage](#usage-of-extract))
+- **extractKeywordsOnly($text, $sortBy, $sortDir)** - provides keywords only ([usage](#usage-of-extractkeywordsonly))
 
 ### Usage of extract()
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ A package to extract keywords from text
 ## Server Requirements
 - PHP >= 7.4
 
-## Usage
--  To install ths package:
+## Installation
+
+You can install the package via composer:
 ```
 composer require keyword-extractor/keyword-extractor
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A package to extract keywords from text
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/iranianpep/keyword-extractor/master/LICENSE)
 
 ## Server Requirements
-- PHP >= 7.3
+- PHP >= 7.4
 
 ## Usage
 -  To install ths package:

--- a/README.md
+++ b/README.md
@@ -247,3 +247,8 @@ Array
 
 )
 ```
+
+
+## License
+
+The MIT License (MIT). Please see the [License file](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ composer require keyword-extractor/keyword-extractor
 ## Usage
 
 The `KeywordExtractor` provides the following public methods:
-- [extract](#usage-of-extract)($text, $sortBy, $sortDir)               # provide extracted keywords with additional information
-- [extractKeywordsOnly](#usage-of-extractkeywordsonly)($text, $sortBy, $sortDir)   # provide extracted keywords only
+- extract($text, $sortBy, $sortDir) - provides keywords with additional information ([usage](#usage-of-extract))
+- extractKeywordsOnly($text, $sortBy, $sortDir) - provides keywords only ([usage](#usage-of-extractkeywordsonly))
 
 ### Usage of extract()
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require-dev": {
     "phpmd/phpmd": "^2.6",
     "squizlabs/php_codesniffer": "^3.2",
-    "phpunit/phpunit": "^9.2"
+    "phpunit/phpunit": "^9.5|^10.0|^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/KeywordExtractor/KeywordExtractor.php
+++ b/src/KeywordExtractor/KeywordExtractor.php
@@ -27,10 +27,10 @@ class KeywordExtractor
      */
     const NGRAM_SIZES = [3, 2, 1];
 
-    private $blacklist = [];
-    private $whitelist = [];
-    private $modifiers;
-    private $keywords;
+    private array $blacklist = [];
+    private array $whitelist = [];
+    private array $modifiers;
+    private array $keywords;
 
     /**
      * @param string $string

--- a/src/KeywordExtractor/KeywordExtractor.php
+++ b/src/KeywordExtractor/KeywordExtractor.php
@@ -41,7 +41,7 @@ class KeywordExtractor
      *
      * @return array
      */
-    public function run(string $string, string $sortBy = '', string $sortDir = Sorter::SORT_DIR_ASC): array
+    public function extract(string $string, string $sortBy = '', string $sortDir = Sorter::SORT_DIR_ASC): array
     {
         // reset the keywords
         $this->keywords = [];
@@ -66,7 +66,7 @@ class KeywordExtractor
 
     public function extractKeywordsOnly(string $string, string $sortBy = '', string $sortDir = Sorter::SORT_DIR_ASC): array
     {
-        $this->run($string, $sortBy, $sortDir);
+        $this->extract($string, $sortBy, $sortDir);
 
         return $this->retrieveKeywords();
     }

--- a/src/KeywordExtractor/KeywordExtractor.php
+++ b/src/KeywordExtractor/KeywordExtractor.php
@@ -64,8 +64,10 @@ class KeywordExtractor
         return $this->keywords;
     }
 
-    public function getKeywords(): array
+    public function extractKeywordsOnly(string $string, string $sortBy = '', string $sortDir = Sorter::SORT_DIR_ASC): array
     {
+        $this->run($string, $sortBy, $sortDir);
+
         return $this->retrieveKeywords();
     }
 

--- a/src/KeywordExtractor/Utility.php
+++ b/src/KeywordExtractor/Utility.php
@@ -7,7 +7,7 @@ class Utility
     /**
      * @param array $array
      *
-     * @return int
+     * @return int|null
      */
     public function findMinDiff(array $array): ?int
     {

--- a/tests/KeywordExtractor/KeywordExtractorTest.php
+++ b/tests/KeywordExtractor/KeywordExtractorTest.php
@@ -21,7 +21,7 @@ class KeywordExtractorTest extends TestCase
     public function testRun(): void
     {
         $text = 'This is a simple sentence.';
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'simpl' => [
@@ -49,12 +49,12 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $text = '';
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([], $result);
 
         $text = '123 this text has got visual studio 2018 and 2019 and more numbers like 12 13 145';
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'text' => [
@@ -104,7 +104,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setWhitelist(['visual studio 2018']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
         $this->assertEquals([
             'visual studio 2018' => [
                 'frequency'   => 1,
@@ -144,7 +144,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setWhitelist(['2018 and 2019']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
         $this->assertEquals([
             '2018 and 2019' => [
                 'frequency'   => 1,
@@ -206,7 +206,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $text = 'This is a text with an email like: example@example.com in it.';
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'text' => [
@@ -234,7 +234,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $text = 'This is a text with two emails: example.example@example.com, and another@example.com.';
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'text' => [
@@ -266,7 +266,7 @@ class KeywordExtractorTest extends TestCase
     {
         $text = 'This is a simple sentence and simple sentence.';
         $this->keywordExtractor->setWhitelist([]);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'simpl' => [
@@ -306,7 +306,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setWhitelist(['simple']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'simple' => [
@@ -346,7 +346,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setWhitelist(['simple', 'is', 'dummy']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'is' => [
@@ -397,7 +397,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setWhitelist(['simple sentence']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'simple sentence' => [
@@ -426,7 +426,7 @@ class KeywordExtractorTest extends TestCase
     {
         $text = 'This is a simple sentence.';
         $this->keywordExtractor->setBlacklist([]);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'simpl' => [
@@ -454,7 +454,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setBlacklist(['simple']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'sentenc' => [
@@ -471,7 +471,7 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setBlacklist(['simple', 'is', 'dummy']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'sentenc' => [
@@ -488,14 +488,14 @@ class KeywordExtractorTest extends TestCase
         ], $result);
 
         $this->keywordExtractor->setBlacklist(['simple sentence']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([], $result);
 
         $text = 'Exciting opportunity';
         $this->keywordExtractor->setBlacklist([]);
         $this->keywordExtractor->setWhitelist([]);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'excit' => [
@@ -524,7 +524,7 @@ class KeywordExtractorTest extends TestCase
 
         $this->keywordExtractor->setBlacklist(['opportun']);
 
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'excit' => [
@@ -564,7 +564,7 @@ PhpStorm, Eclipse or other IDE';
         $this->keywordExtractor->setWhitelist(['version control', 'php', 'composer', 'google cloud']);
         $this->keywordExtractor->setBlacklist(['software', 'etc']);
 
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertArrayHasKey('linux', $result);
         $this->assertArrayHasKey('php', $result);
@@ -575,7 +575,7 @@ PhpStorm, Eclipse or other IDE';
         $this->assertArrayHasKey('environ', $result);
 
         $this->keywordExtractor->setBlacklist(['software', 'etc', 'environments']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertArrayNotHasKey('environ', $result);
 
@@ -585,7 +585,7 @@ PhpStorm, Eclipse or other IDE';
 
         $this->keywordExtractor->setBlacklist(['includes', 'keywords']);
         $this->keywordExtractor->setWhitelist(['jquery', 'iis']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         /*
          * Did not use loop because if one of the tests fail, it's easier to find out which one failed
@@ -637,7 +637,7 @@ who has great people than this is an opportunity you need to explore further...'
         $this->keywordExtractor->setBlacklist([]);
         $this->keywordExtractor->setWhitelist(['react native']);
 
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertArrayHasKey('microservic', $result);
         $this->assertArrayHasKey('react', $result);
@@ -649,7 +649,7 @@ who has great people than this is an opportunity you need to explore further...'
         $text = "What we're interested is c#, .net and asp but mainly c# and c#.";
         $this->keywordExtractor->setWhitelist(['c#', '.net', 'asp']);
         $this->keywordExtractor->setBlacklist(['interest', 'c#,']);
-        $result = $this->keywordExtractor->run($text);
+        $result = $this->keywordExtractor->extract($text);
 
         $this->assertEquals([
             'c#' => [
@@ -745,13 +745,13 @@ who has great people than this is an opportunity you need to explore further...'
     public function testRunSortedByFrequency(): void
     {
         $text = '2 simple sentences and only one sentence.';
-        $result = $this->keywordExtractor->run($text, Sorter::SORT_BY_FREQUENCY);
+        $result = $this->keywordExtractor->extract($text, Sorter::SORT_BY_FREQUENCY);
 
         $this->assertEquals(2, $result['sentenc']['frequency']);
 
         // result should be the same
         $text = '2 sentences and only one simple sentence.';
-        $result = $this->keywordExtractor->run($text, Sorter::SORT_BY_FREQUENCY);
+        $result = $this->keywordExtractor->extract($text, Sorter::SORT_BY_FREQUENCY);
 
         $this->assertEquals(2, $result['sentenc']['frequency']);
 
@@ -762,7 +762,7 @@ who has great people than this is an opportunity you need to explore further...'
         $arrayItem = array_shift($result);
         $this->assertEquals($arrayItem['frequency'], 2);
 
-        $result = $this->keywordExtractor->run(
+        $result = $this->keywordExtractor->extract(
             $text,
             Sorter::SORT_BY_FREQUENCY,
             Sorter::SORT_DIR_DESC
@@ -782,22 +782,22 @@ who has great people than this is an opportunity you need to explore further...'
     public function testRunSortedByMidOccurrenceDistance(): void
     {
         $text = 'sentence and sentence';
-        $result = $this->keywordExtractor->run($text, Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE);
+        $result = $this->keywordExtractor->extract($text, Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE);
 
         $this->assertEquals(1, $result['sentenc']['minOccurrencesDistance']);
 
         $text = 'sentence sentence';
-        $result = $this->keywordExtractor->run($text, Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE);
+        $result = $this->keywordExtractor->extract($text, Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE);
 
         $this->assertEquals(0, $result['sentenc']['minOccurrencesDistance']);
 
         $text = 'sentence';
-        $result = $this->keywordExtractor->run($text, Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE);
+        $result = $this->keywordExtractor->extract($text, Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE);
 
         $this->assertEquals(null, $result['sentenc']['minOccurrencesDistance']);
 
         $text = 'john james john john to james joe john joe';
-        $result = $this->keywordExtractor->run(
+        $result = $this->keywordExtractor->extract(
             $text,
             Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE
         );
@@ -806,7 +806,7 @@ who has great people than this is an opportunity you need to explore further...'
         // john
         $this->assertEquals(0, $arrayItem['minOccurrencesDistance']);
 
-        $result = $this->keywordExtractor->run(
+        $result = $this->keywordExtractor->extract(
             $text,
             Sorter::SORT_BY_MIN_OCCURRENCE_DISTANCE,
             Sorter::SORT_DIR_DESC

--- a/tests/KeywordExtractor/KeywordExtractorTest.php
+++ b/tests/KeywordExtractor/KeywordExtractorTest.php
@@ -707,9 +707,9 @@ who has great people than this is an opportunity you need to explore further...'
     {
         $service = new KeywordExtractor();
 
-        $service->run($inputText);
+        $keywords = $service->extractKeywordsOnly($inputText);
 
-        $this->assertSame($expected, $service->getKeywords());
+        $this->assertSame($expected, $keywords);
     }
 
     public static function provideCasesForGetKeywords(): array


### PR DESCRIPTION
In continuation of #21, this is my proposal. This PR finally breaks the backward compatibility, so a major release seems to be inevitable. I'd like to propose changing in the public interface with this major release.

The first thing is to rename the `run` method into `extract`. Personally to me, a `run()` method should not return anything (in the majority of projects that I've seen it returns void). So, `extract()` method seems better in this case (semantically at least). Renaming it opens the way to name other methods in the consistent way. So, the new `getKeywords()` method may be renamed into `extractKeywordsOnly()`.

P.S. I've updated the README too.
